### PR TITLE
Proper sourcemod search on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 Self-developed improvements for TF2 Classic downloader
+
 https://github.com/tf2classic/TF2CDownloader

--- a/README.md
+++ b/README.md
@@ -1,10 +1,2 @@
-# TF2CDownloader
-Simple script for downloading and extracting TF2Classic quickly, simply, and efficiently.
-
-Won't function right on Windows unless it's compiled by PyInstaller, as it's hardcoded to use a variable only supplied to it *by* PyInstaller in order to find the Binaries folder.
-
-In the Binaries folder of the repository, Aria2 and its relevant dependencies are from MSYS2: https://packages.msys2.org/package/mingw-w64-x86_64-aria2
-
-7za.exe is extracted from 7-Zip Extra 21.07: https://www.7-zip.org/a/7z2107-extra.7z
-
-The contents of this folder can be freely replaced with your own builds of these tools, as long as aria2c.exe and 7za.exe are present.
+Self-developed improvements for TF2 Classic downloader
+https://github.com/tf2classic/TF2CDownloader

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# TF2CDownloader
 Self-developed improvements for TF2 Classic downloader
+Simple script for downloading and extracting TF2Classic quickly, simply, and efficiently.
 
+
+Won't function right on Windows unless it's compiled by PyInstaller, as it's hardcoded to use a variable only supplied to it *by* PyInstaller in order to find the Binaries folder.
 https://github.com/tf2classic/TF2CDownloader
+
+In the Binaries folder of the repository, Aria2 and its relevant dependencies are from MSYS2: https://packages.msys2.org/package/mingw-w64-x86_64-aria2
+
+7za.exe is extracted from 7-Zip Extra 21.07: https://www.7-zip.org/a/7z2107-extra.7z
+
+The contents of this folder can be freely replaced with your own builds of these tools, as long as aria2c.exe and 7za.exe are present.

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,14 @@ def sourcemods_path():
 			return None
 	else:
 		try:
-			linux_dirs = {
-				'~/.steam/steam/steamapps/sourcemods/',
-				# these locations are mentioned in old posts on forums, so it's better to check them too
-				'~/.local/share/Steam/SteamApps/sourcemods',
-				'~/Steam/SteamApps/sourcemods'
-			}
-			for dir in linux_dirs:
-				if os_path.isdir(dir):
-					return dir
-			return None
+			sourcepath = None
+			with open(os_path.expanduser('~/.steam/registry.vdf'), 'r') as file:
+				for _, line in enumerate(file):
+					if 'SourceModInstallPath' in line:
+						sourcepath = line[line.index('/home'):-1].replace(r'\\', '/')
+						break
+				file.close()
+			return sourcepath
 		except Exception:
 			return None
 


### PR DESCRIPTION
No longer searching by common locations, using registry.vdf instead.

Fixes #2