### PR TITLE
Fixed script mode so it can update the game again

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -20,7 +20,7 @@ def message(msg, delay = 0):
     if not vars.SCRIPT_MODE:
         sleep(delay)
 
-def message_yes_no(msg, default = None, script_mode_default_override=None):
+def message_yes_no(msg: str, default: bool = None, script_mode_default_override:bool = None) -> bool:
     """
     Show a message to user and get yes/no answer.
     """
@@ -33,11 +33,7 @@ def message_yes_no(msg, default = None, script_mode_default_override=None):
             return script_mode_default_override
         return default
     
-    valid = {}
-    valid["yes"] = True
-    valid["no"] = False
-    valid["y"] = True
-    valid["n"] = False
+    valid = {"yes": True, "no": False, "y": True, "n": False}
 
     localyes = _("yes")
     localno = _("no")
@@ -47,9 +43,9 @@ def message_yes_no(msg, default = None, script_mode_default_override=None):
     valid[localno[0]] = False
 
     prompt = _(" {y/n}")
-    if default == "y":
+    if default:
         prompt = _(" {Y/n}")
-    elif default == "n":
+    elif default is not None:
         prompt = _(" {y/N}")
     msg += prompt
 
@@ -57,7 +53,7 @@ def message_yes_no(msg, default = None, script_mode_default_override=None):
         print(msg)
         choice = input().lower()
         if default is not None and choice == "":
-            return valid[default]
+            return default
         elif choice in valid:
             return valid[choice]
         else:

--- a/gui.py
+++ b/gui.py
@@ -20,13 +20,19 @@ def message(msg, delay = 0):
     if not vars.SCRIPT_MODE:
         sleep(delay)
 
-def message_yes_no(msg, default = None):
+def message_yes_no(msg, default = None, script_mode_default_override=None):
     """
     Show a message to user and get yes/no answer.
     """
     if vars.SCRIPT_MODE:
+        # Display msg even though we are in script mode, this because it might
+        # contain useful information.
+        print(msg)
+        print(_("The application is in script mode, using default choice."))
+        if script_mode_default_override is not None:
+            return script_mode_default_override
         return default
-
+    
     valid = {}
     valid["yes"] = True
     valid["no"] = False
@@ -90,6 +96,6 @@ def message_end(msg, code):
     print("[bold green]" + msg)
     if environ.get("WT_SESSION"):
         print(_("[bold]You are safe to close this window."))
-    else:
+    elif not vars.SCRIPT_MODE:
         input(_("Press Enter to exit."))
     exit(code)

--- a/tf2c_downloader.py
+++ b/tf2c_downloader.py
@@ -150,7 +150,7 @@ path will be the current work directory.'''
                 print(_("TF2 Classic isn't installed, cannot do an update. Consider using --install instead."))
                 exit(1)
             else:
-                vars.INSTALLED = versions.update_version_file(True)
+                vars.INSTALLED = versions.update_version_file()
                 if versions.check_for_updates() == 'reinstall':
                     downloads.install()
                     troubleshoot.apply_blacklist()

--- a/versions.py
+++ b/versions.py
@@ -88,7 +88,7 @@ def check_for_updates():
             gui.message_end(_("We have nothing to do. Goodbye!"), 0)
 
     found = False
-    for ver in VERSION_LIST["versions"]:
+    for ver in get_version_list()["versions"]:
         if ver["ver"] == local_version:
             found = True
             break
@@ -106,9 +106,8 @@ def check_for_updates():
             return 'reinstall'
         else:
             gui.message_end(_("We have nothing to do. Goodbye!"), 0)
-
     if patch_chain(local_version, latest_version):
-        if gui.message_yes_no(_("An update is available for your game. Do you want to install it?"), 0):
+        if gui.message_yes_no(_("An update is available for your game. Do you want to install it?"), None, True):
             return 'update'
         else:
             if gui.message_yes_no(_("In that case, do you want to reinstall completely?"), 0):
@@ -117,7 +116,7 @@ def check_for_updates():
                 gui.message_end(_("We have nothing to do. Goodbye!"), 0)
     else:
         # We did not find an applicable patch chain to properly update the game, forcing us to relie on the ol' reinstallation method.
-        if gui.message_yes_no(_("An update is available for your game. Do you want to install it?"), 0):
+        if gui.message_yes_no(_("An update is available for your game. Do you want to install it?"), None, True):
             return 'reinstall'
         else:
             gui.message_end(_("We have nothing to do. Goodbye!"), 0)


### PR DESCRIPTION
Small pr that fixes a few bugs with the downloader. Things such as `update_version_file` being used with an argument that doesn't exist, error messages not being displayed because they are part of a question and the default option for updating being None causing script mode to never actually update the game.

To keep the old default behaviour I added an override option for script mode that allows us to specify the option that we would probably want to use when in script mode. This is especially useful when the default is None.

I also took a look at `message_yes_no` since the types are a little messed up. Default is expected to be a string but we also return default if we are in script mode but the return value is actually a boolean so there are some wrong assumptions here. I added some type hints to make sure we don't get confused in the future, the real value we use as default these days are booleans but the code wasn't really adjusted for that yet.