### PR TITLE
Symlink specific files

### DIFF
--- a/vars.py
+++ b/vars.py
@@ -22,3 +22,8 @@ TF2C_PATH = None
 SCRIPT_MODE = len(sys.argv) > 1
 
 SOURCE_URL = 'https://raw.githubusercontent.com/tf2classic/TF2C-Meta/main/'
+
+# Only on Linux
+TO_SYMLINK = [
+    ["/tf2classic/bin/server.so", "/tf2classic/bin/server_srv.so"]
+]


### PR DESCRIPTION
As of right now, it only symlink the `server_srv.so` file (to `server.so`, since these are identical but large files) whenever it doesn't appear when updating.