### PR TITLE
Typo in french translation

### DIFF
--- a/locale/fr/LC_MESSAGES/tf2c-downloader.po
+++ b/locale/fr/LC_MESSAGES/tf2c-downloader.po
@@ -109,7 +109,7 @@ msgstr ""
 "Bienvenue sur TF2CDownloader. Entrez un nombre pour continuer.\n"
 "\n"
 "        1 - Installer ou réinstaller le jeu\n"
-"        3 - Rechercher et appliquer des mises à jour\n"
+"        2 - Rechercher et appliquer des mises à jour\n"
 "        3 - Vérifier et réparer les fichiers du jeu"
 
 #: gui.py:32 gui.py:42


### PR DESCRIPTION
The number selector showed 1, 3, 3 instead of 1, 2, 3